### PR TITLE
Revert "initial update for GovWifi migration from GDS"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
-      - uses: actions/cache@v4
+      - uses: actions/cache@v1
         with:
           path: vendor/bundle
           key: bundle-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ It will look at the pages API for your site, find all pages that have expired, a
 
 ## Usage
 
-### `GovWifi` users
+### `alphagov` users
 
-If you are part of the `govwifi` GitHub organisation you can enable the notifier by raising a PR to add your published documentation to the [`Rakefile`](Rakefile):
+If you are part of the `alphagov` GitHub organisation you can enable the notifier by raising a PR to add your published documentation to the [`Rakefile`](Rakefile):
 
 ```
 pages_urls = [
-    "https://dev-docs.wifi.service.gov.uk/api/pages.json",
-    "https://docs.wifi.service.gov.uk/api/pages.json",
+  "https://gds-way.cloudapps.digital/api/pages.json",
+  "https://docs.publishing.service.gov.uk/api/pages.json",
+  "your-docs-site.cloudapps.digital"
 ]
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,9 @@ task default: ["notify:expired"]
 
 namespace :notify do
   pages_urls = [
+    "https://gds-way.digital.cabinet-office.gov.uk/api/pages.json",
+    "https://docs.payments.service.gov.uk/api/pages.json",
+    "https://team-manual.account.gov.uk/api/pages.json",
     "https://dev-docs.wifi.service.gov.uk/api/pages.json",
     "https://docs.wifi.service.gov.uk/api/pages.json",
   ]


### PR DESCRIPTION
Reverts GovWifi/tech-docs-monitor#2

This code is not working as anticipated, returning to forked version.