### PR TITLE
Remove Heroku reference

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,10 +17,5 @@
   },
   "addons": [
     "scheduler:standard"
-  ],
-  "buildpacks": [
-    {
-      "url": "https://github.com/heroku/heroku-buildpack-ruby.git"
-    }
   ]
 }


### PR DESCRIPTION
What
Remove Heroku reference

Why
Keeping deprecated or irrelevant code in codebase is bad practice, causes mental overhead and can potentially cause security vulnerabilities.

Link to Jira card (if applicable):
[GW-1876](https://technologyprogramme.atlassian.net/browse/GW-1876)